### PR TITLE
Add key to product listing in cart

### DIFF
--- a/resources/views/components/product/product-tile.blade.php
+++ b/resources/views/components/product/product-tile.blade.php
@@ -1,7 +1,7 @@
 @slots(['name', 'quantity'])
 
 <div {{ $attributes->class('divide-y divide-dashed [&>:first-child]:pt-0') }}>
-    <div v-for="(item, index) in cart.items" class="flex gap-y-5 py-5 lg:pb-4 lg:pt-5">
+    <div v-for="(item, index) in cart.items" class="flex gap-y-5 py-5 lg:pb-4 lg:pt-5" :key="item.id">
         @include('rapidez-ct::components.product.partials.image')
         <div class="flex flex-wrap items-start justify-between gap-x-2 gap-y-4 w-full ml-2">
             @isset($name)


### PR DESCRIPTION
This not being there caused the "item removed from cart" to say the wrong item.

By the way, does it make sense to have the v-for in here? The component is called `tile` so I wouldn't expect multiple tile*s*. Does it make sense to rename it to `product-tiles`?