### PR TITLE
[2.x] - Remove border right on last item

### DIFF
--- a/resources/views/checkout/partials/sidebar/products.blade.php
+++ b/resources/views/checkout/partials/sidebar/products.blade.php
@@ -7,7 +7,7 @@
                     @{{ item.product.name }}
                 </span>
                 <div class="*:border-r last:*:border-r-0 last:*:pr-0 *:pr-2 flex flex-wrap gap-x-2 text-xs text-ct-inactive">
-                    <div class="*:border-r *:px-2 *:mb-2 *:leading-3 -mx-2 mt-2 flex flex-wrap text-xs text-inactive subpixel-antialiased">
+                    <div class="*:border-r *:px-2 *:mb-2 *:leading-3 last:*:border-r-0 -mx-2 mt-2 flex flex-wrap text-xs text-inactive subpixel-antialiased">
                         <div v-for="option in item.configurable_options">
                             @{{ option.value_label }}
                         </div>
@@ -15,7 +15,7 @@
                             @{{ option.label }}: @{{ option.values[0].label || option.values[0].value }}
                         </div>
                         <div v-for="option in config.cart_attributes" v-if="item.product.attribute_values?.[option] && typeof item.product.attribute_values[option] === 'object'">
-                            @{{ option }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span>
+                            <p class="normal-case first-letter:uppercase">@{{ option.replace(/_/g, ' ') }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span></p>
                         </div>
                     </div>
                 </div>

--- a/resources/views/components/product/partials/name.blade.php
+++ b/resources/views/components/product/partials/name.blade.php
@@ -2,7 +2,7 @@
     <a class="hover:underline" :href="item.product.url_key + item.product.url_suffix | url">
         <div class="font-semibold text-sm" dusk="cart-item-name">@{{ item.product.name }}</div>
     </a>
-    <div class="flex flex-wrap *:border-r -mx-2 *:px-2 text-inactive text-xs subpixel-antialiased mt-2 *:mb-2 *:leading-3">
+    <div class="flex flex-wrap *:border-r last:*:border-r-0 -mx-2 *:px-2 text-inactive text-xs subpixel-antialiased mt-2 *:mb-2 *:leading-3">
         <div v-for="option in item.configurable_options">
                 @{{ option.value_label }}
             </div>
@@ -10,7 +10,7 @@
             @{{ option.label }}: @{{ option.values[0].label || option.values[0].value }}
         </div>
         <div v-for="option in config.cart_attributes" v-if="item.product.attribute_values?.[option] && typeof item.product.attribute_values[option] === 'object'">
-            @{{ option }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span>
+            <p class="normal-case first-letter:uppercase">@{{ option.replace(/_/g, ' ') }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span></p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Removed border right for the last item. 

Show product attributes better:
snake_case -> Removed the _ and replace it for a space
lowercase changed so first-letter will have an uppercase. 

_Example:_
<img width="188" alt="Scherm­afbeelding 2025-01-10 om 10 29 34" src="https://github.com/user-attachments/assets/fe344773-0a31-4f2c-90b5-ce9df31e2396" />

