### PR TITLE
Add margin bottom for spacing below the progressbar

### DIFF
--- a/resources/views/components/title-progress-bar.blade.php
+++ b/resources/views/components/title-progress-bar.blade.php
@@ -1,6 +1,6 @@
 @aware(['checkoutSteps', 'currentStep', 'currentStepKey'])
 
-<div class="flex flex-wrap items-baseline justify-between gap-1">
+<div class="flex flex-wrap items-baseline justify-between gap-1 mb-4">
     <x-rapidez-ct::title {{ $attributes->except(['checkoutSteps', 'currentStep', 'currentStepKey']) }}>
         {{ $slot }}
     </x-rapidez-ct::title>


### PR DESCRIPTION
Add margin bottom for spacing below the progressbar as items now are to close to the progessbar. 