### PR TITLE
[4.x] Use `taxTotal` because that actually exists as opposed to `tax`

### DIFF
--- a/resources/views/components/summary.blade.php
+++ b/resources/views/components/summary.blade.php
@@ -9,9 +9,9 @@
             <div class="font-medium text-base" v-text="$options.filters.price({{ $type }}.prices?.subtotal_including_tax?.value ?? {{ $type }}.total?.subtotal?.value)"></div>
         </div>
     </li>
-    <li v-if="{{ $type }}.tax > 0">
+    <li v-if="{{ $type }}.taxTotal > 0">
         <div>@lang('Tax')</div>
-        <div class="font-medium" v-text="$options.filters.price({{ $type }}.prices.applied_taxes[0].amount.value)"></div>
+        <div class="font-medium" v-text="$options.filters.price({{ $type }}.taxTotal)"></div>
     </li>
     <li v-for="discount in {{ $type }}?.prices?.discounts">
         <div>@{{ discount.label }}</div>


### PR DESCRIPTION
This won't work for the order data (in the checkout success) as that's different data. I don't really understand why we chose the approach of completely overwriting all of the sidebars everywhere and replacing it all with a single component that doesn't do its job, when we literally already have working sidebars in the core (that have also been unnecessarily overwritten in checkout-theme, but that's a different story).

Either way, this is a quick patch to fix tax not being shown in the cart.