### PR TITLE
[5.x] Add class to shipping method display in summary

### DIFF
--- a/resources/views/cart/partials/sidebar/summary.blade.php
+++ b/resources/views/cart/partials/sidebar/summary.blade.php
@@ -11,7 +11,7 @@
     <template v-if="cart.value.shipping_addresses?.length">
         <div v-for="address in cart.value.shipping_addresses">
             <template v-if="address?.selected_shipping_method">
-                <dt>
+                <dt class="flex flex-col max-w-52">
                     @lang('Shipping')
                     <small class="text-muted">@{{ address.selected_shipping_method.carrier_title }} - @{{ address.selected_shipping_method.method_title }}</small>
                 </dt>


### PR DESCRIPTION
```
<small class="text-muted">@{{ address.selected_shipping_method.carrier_title }} - @{{ address.selected_shipping_method.method_title }}</small>
```

When this text is to the text summary doesn't look very nice anymore: 
<img width="367" height="259" alt="Screenshot 2026-06-11 at 11 36 12" src="https://github.com/user-attachments/assets/ca2d7b71-bb58-46ff-96c7-4c92cd1d6f91" />
