### PR TITLE
[5.x] Fix mobile container

### DIFF
--- a/resources/views/checkout/pages/credentials.blade.php
+++ b/resources/views/checkout/pages/credentials.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
     <div class="overflow-clip">
-        <div class="lg:container xl:max-w-7xl">
+        <div class="container xl:max-w-7xl">
             <x-rapidez-ct::layout.checkout>
                 <x-slot:header>
                     @include('rapidez-ct::checkout.partials.header', ['href' => route('cart')])

--- a/resources/views/checkout/pages/login.blade.php
+++ b/resources/views/checkout/pages/login.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
     <div class="overflow-clip">
-        <div class="lg:container xl:max-w-7xl">
+        <div class="container xl:max-w-7xl">
             <x-rapidez-ct::layout.checkout>
                 <x-slot:header>
                     @include('rapidez-ct::checkout.partials.header', ['href' => route('cart')])

--- a/resources/views/checkout/pages/payment.blade.php
+++ b/resources/views/checkout/pages/payment.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
     <div class="overflow-clip">
-        <div class="lg:container xl:max-w-7xl">
+        <div class="container xl:max-w-7xl">
             <x-rapidez-ct::layout.checkout>
                 <x-slot:header>
                     @include('rapidez-ct::checkout.partials.header', ['href' => route('cart')])


### PR DESCRIPTION
I am not sure why we added the `lg` breakpoint for the `container` but on mobile there was no container so everything was to the edge of te screen. 
